### PR TITLE
Adding late player to ongoing round.

### DIFF
--- a/ANRTournament/Objects/Player.cs
+++ b/ANRTournament/Objects/Player.cs
@@ -50,6 +50,7 @@ namespace ANRTournament.Objects
         private int bucholz = 0;
         private int mbucholz = 0;
         private bool payment = false;
+        private bool addPlayerToLastRound = false;
 
         private int runnerwins = 0;
         private int corpowins = 0;
@@ -436,6 +437,22 @@ namespace ANRTournament.Objects
                 {
                     this.payment = value;
                     NotifyPropertyChanged("Payment");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Dodaj do ostatniej rundy
+        /// </summary>
+        public bool AddPlayerToLastRound
+        {
+            get { return this.addPlayerToLastRound; }
+            set
+            {
+                if (value != this.addPlayerToLastRound)
+                {
+                    this.addPlayerToLastRound = value;
+                    NotifyPropertyChanged("AddPlayerToLastRound");
                 }
             }
         }

--- a/ANRTournament/Objects/Tournament.cs
+++ b/ANRTournament/Objects/Tournament.cs
@@ -902,6 +902,39 @@ namespace ANRTournament.Objects
                     this.allGames.Remove(game);
                 }
             }
+
+            if (Rounds.Count > 0)
+            {
+                bool addToLastRound = playerToAdd.AddPlayerToLastRound;
+                if (addToLastRound)
+                {
+                    ObservableCollection<Round> activeRounds = Rounds;
+                    Round lastRound = activeRounds[activeRounds.Count - 1];
+                    Game lastGame = lastRound.Games[lastRound.Games.Count - 1];
+                    if (lastGame.IsBYE)
+                    {
+                        lastGame.IsBYE = false;
+                        lastGame.Player2Alias = playerToAdd.Alias;
+                        lastGame.Player2Id = playerToAdd.Id;
+                        lastGame.Player2RaceCorpo = playerToAdd.RaceCorpo;
+                        lastGame.Player2RaceRunner = playerToAdd.RaceRunner;
+                    }
+                    else
+                    {
+                        Game game = new Game()
+                        {
+                            Player1Alias = playerToAdd.Alias,
+                            Player1Id = playerToAdd.Id,
+                            Player1RaceCorpo = playerToAdd.RaceCorpo,
+                            Player1RaceRunner = playerToAdd.RaceRunner,
+                            IsBYE = true,
+                            Number = lastGame.Number + 1,
+                        };
+                        lastRound.Games.Add(game);
+                    }
+
+                }
+            }
         }
 
         public void ActivatePlayer(Player playerToActivate)

--- a/ANRTournament/PlayerWindow.xaml
+++ b/ANRTournament/PlayerWindow.xaml
@@ -149,9 +149,24 @@
                   Grid.ColumnSpan="2"
                   Grid.Column="0"
                   HorizontalAlignment="Right"
-                  Margin="0,10,185,20"
+                  Margin="0,10,265,20"
                   FlowDirection="RightToLeft"
                   Content="{lex:Loc MainWindow_CMenu_Payment}">
+            <CheckBox.Resources>
+                <Style TargetType="{x:Type Path}">
+                    <Setter Property="FlowDirection" Value="LeftToRight"/>
+                </Style>
+            </CheckBox.Resources>
+        </CheckBox>
+
+        <CheckBox x:Name="chkAddPlayerToLastRound"
+                  IsChecked="{Binding AddPlayerToLastRound, Mode=TwoWay}"
+                  Grid.Row="8"
+                  Grid.Column="1"
+                  HorizontalAlignment="Left"
+                  Margin="10,10,0,20"
+                  FlowDirection="LeftToRight"
+                  Content="{lex:Loc MainWindow_CMenu_AddPlayerToLastRound}">
             <CheckBox.Resources>
                 <Style TargetType="{x:Type Path}">
                     <Setter Property="FlowDirection" Value="LeftToRight"/>
@@ -164,7 +179,7 @@
                 Grid.Row="9" 
                 VerticalAlignment="Bottom"
                 HorizontalAlignment="Left" 
-                Margin="20,0,0,5" 
+                Margin="45,0,0,5" 
                 Name="btnOk"
                 Width="100" 
                 Height="23"/>

--- a/ANRTournament/Resources/StringTable.de.resx
+++ b/ANRTournament/Resources/StringTable.de.resx
@@ -633,6 +633,9 @@ Möchtest du fortfahren?</value>
   <data name="MainWindow_CMenu_Payment" xml:space="preserve">
     <value>Zahlung</value>
   </data>
+  <data name="MainWindow_CMenu_AddPlayerToLastRound" xml:space="preserve">
+    <value>Füge Spieler auf der letzten Runde</value>
+  </data>
   <data name="SettingsWindow_BYEDlaPrzegranych" xml:space="preserve">
     <value>Freilos nur für Verlierer</value>
   </data>

--- a/ANRTournament/Resources/StringTable.en.resx
+++ b/ANRTournament/Resources/StringTable.en.resx
@@ -639,6 +639,9 @@ Path: {0}
   <data name="MainWindow_CMenu_Payment" xml:space="preserve">
     <value>Payment</value>
   </data>
+  <data name="MainWindow_CMenu_AddPlayerToLastRound" xml:space="preserve">
+    <value>Add player to the last round</value>
+  </data>
   <data name="SettingsWindow_BYEDlaPrzegranych" xml:space="preserve">
     <value>BYE only for loser</value>
   </data>

--- a/ANRTournament/Resources/StringTable.resx
+++ b/ANRTournament/Resources/StringTable.resx
@@ -648,6 +648,9 @@ Czy chcesz kontynuować?</value>
   <data name="MainWindow_CMenu_Payment" xml:space="preserve">
     <value>Płatność</value>
   </data>
+  <data name="MainWindow_CMenu_AddPlayerToLastRound" xml:space="preserve">
+    <value>Dodaj gracza do ostatniej rundy</value>
+  </data>
   <data name="SettingsWindow_BYEDlaPrzegranych" xml:space="preserve">
     <value>BYE tylko dla przegranych</value>
   </data>


### PR DESCRIPTION
There was a problem with late players, adding them to ongoing round
required deleting and manually restoring last round.

Changes:
- added checkbox in "Add new player" window with text "Add player to
  last round"
- if number of rounds > 0, the new player is added to last round either
  as a pair to player with BYE, or  as a player with BYE
  -checkbox "Add player to last round" was translated to polish and german
  according to game's language menu.
