### PR TITLE
Issue #33: updated number of points for superbye from 4 to 6

### DIFF
--- a/ANRTournament/Objects/Tournament.cs
+++ b/ANRTournament/Objects/Tournament.cs
@@ -1051,7 +1051,7 @@ namespace ANRTournament.Objects
 
                 if (player.SuperBYE)
                 {
-                    points += 4;
+                    points += 6;
                     gameswin++;
                     smallpointsplus += 20;
                     runnerwins++;


### PR DESCRIPTION
Changing number of points for win does not suffice. Additional change for superbye from 4 to 6 points needed.
